### PR TITLE
fix(db): fix default column value on migration

### DIFF
--- a/shared/src/commonMain/sqldelight/fr/outadoc/justchatting/data/db/User.sq
+++ b/shared/src/commonMain/sqldelight/fr/outadoc/justchatting/data/db/User.sq
@@ -1,8 +1,8 @@
 CREATE TABLE User (
     `id` TEXT NOT NULL,
     `used_at` INTEGER NOT NULL,
-    `followed_at` INTEGER NOT NULL,
-    `inserted_at` INTEGER NOT NULL,
+    `followed_at` INTEGER NOT NULL DEFAULT 0,
+    `inserted_at` INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (`id`)
 );
 

--- a/shared/src/commonMain/sqldelight/migrations/2.sqm
+++ b/shared/src/commonMain/sqldelight/migrations/2.sqm
@@ -1,8 +1,8 @@
 ALTER TABLE recent_emotes RENAME TO RecentEmote;
 ALTER TABLE recent_channels RENAME TO User;
 
-ALTER TABLE User ADD COLUMN `followed_at` INTEGER NOT NULL;
-ALTER TABLE User ADD COLUMN `inserted_at` INTEGER NOT NULL;
+ALTER TABLE User ADD COLUMN `followed_at` INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE User ADD COLUMN `inserted_at` INTEGER NOT NULL DEFAULT 0;
 
 UPDATE User SET inserted_at = strftime('%s', 'now');
 


### PR DESCRIPTION
Attempt to fix migration crash:

```
          Fatal Exception: android.database.sqlite.SQLiteException: Cannot add a NOT NULL column with default value NULL (code 1 SQLITE_ERROR[1])
       at android.database.sqlite.SQLiteConnection.nativeExecuteForChangedRowCount(SQLiteConnection.java)
       at android.database.sqlite.SQLiteConnection.executeForChangedRowCount(SQLiteConnection.java:1241)
       at android.database.sqlite.SQLiteSession.executeForChangedRowCount(SQLiteSession.java:756)
       at android.database.sqlite.SQLiteStatement.executeUpdateDelete(SQLiteStatement.java:67)
       at androidx.sqlite.db.framework.FrameworkSQLiteStatement.executeUpdateDelete(FrameworkSQLiteStatement.kt:3)
       at app.cash.sqldelight.driver.android.AndroidPreparedStatement.execute(AndroidSqliteDriver.kt:3)
       at app.cash.sqldelight.driver.android.AndroidSqliteDriver$execute$2.invoke(AndroidSqliteDriver.kt:8)
       at app.cash.sqldelight.driver.android.AndroidSqliteDriver$execute$2.invoke(AndroidSqliteDriver.kt:8)
       at app.cash.sqldelight.driver.android.AndroidSqliteDriver.execute-zeHU3Mk(AndroidSqliteDriver.kt:30)
       at app.cash.sqldelight.driver.android.AndroidSqliteDriver.J(AndroidSqliteDriver.kt:9)
       at app.cash.sqldelight.db.SqlDriver$DefaultImpls.execute$default(SqlDriver.java:39)
       at fr.outadoc.justchatting.data.db.shared.AppDatabaseImpl$Schema.migrate-zeHU3Mk(AppDatabaseImpl.kt:59)
       at fr.outadoc.justchatting.data.db.shared.AppDatabaseImpl$Schema.migrate(AppDatabaseImpl.kt:59)
       at app.cash.sqldelight.driver.android.AndroidSqliteDriver$Callback.onUpgrade(AndroidSqliteDriver.kt:20)
       at androidx.sqlite.db.framework.FrameworkSQLiteOpenHelper$OpenHelper.onUpgrade(FrameworkSQLiteOpenHelper.kt:15)
       at android.database.sqlite.SQLiteOpenHelper.getDatabaseLocked(SQLiteOpenHelper.java:521)
       at android.database.sqlite.SQLiteOpenHelper.getWritableDatabase(SQLiteOpenHelper.java:419)
       at androidx.sqlite.db.framework.FrameworkSQLiteOpenHelper$OpenHelper.getWritableOrReadableDatabase(FrameworkSQLiteOpenHelper.kt:1)
       at androidx.sqlite.db.framework.FrameworkSQLiteOpenHelper$OpenHelper.innerGetDatabase(FrameworkSQLiteOpenHelper.kt:64)
       at androidx.sqlite.db.framework.FrameworkSQLiteOpenHelper$OpenHelper.getSupportDatabase(FrameworkSQLiteOpenHelper.kt:24)
       at androidx.sqlite.db.framework.FrameworkSQLiteOpenHelper.getWritableDatabase(FrameworkSQLiteOpenHelper.kt:9)
       at app.cash.sqldelight.driver.android.AndroidSqliteDriver$database$2.invoke(AndroidSqliteDriver.kt:7)
       at app.cash.sqldelight.driver.android.AndroidSqliteDriver$database$2.invoke(AndroidSqliteDriver.kt:7)
       at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:21)
       at app.cash.sqldelight.driver.android.AndroidSqliteDriver.getDatabase(AndroidSqliteDriver.kt:3)
       at app.cash.sqldelight.driver.android.AndroidSqliteDriver.P0(AndroidSqliteDriver.kt:19)
       at app.cash.sqldelight.TransacterImpl.transactionWithWrapper(Transacter.kt:3)
       at app.cash.sqldelight.TransacterImpl.transaction(Transacter.kt:3)
       at app.cash.sqldelight.Transacter$DefaultImpls.transaction$default(Transacter.kt:26)
       at fr.outadoc.justchatting.feature.recent.data.LocalUsersDb$rememberUser$2.invokeSuspend(LocalUsersDb.kt:26)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:9)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:93)
       at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:4)
       at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:3)
       at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.java:98)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:98)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:98)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:98)
```