### PR TITLE
fix: harden chat against malformed server data and fix core chat bugs

### DIFF
--- a/shared-ui/src/androidMain/kotlin/fr/outadoc/justchatting/di/UiModule.android.kt
+++ b/shared-ui/src/androidMain/kotlin/fr/outadoc/justchatting/di/UiModule.android.kt
@@ -8,6 +8,6 @@ import org.koin.dsl.module
 
 internal val androidUiModule =
     module {
-        single<ChatNotifier> { AndroidChatNotifier(get(), get()) }
+        single<ChatNotifier> { AndroidChatNotifier(get()) }
         single<CreateShortcutForChannelUseCase> { AndroidCreateShortcutForChannelUseCase(get()) }
     }

--- a/shared-ui/src/androidMain/kotlin/fr/outadoc/justchatting/feature/chat/presentation/ui/AndroidChatNotifier.kt
+++ b/shared-ui/src/androidMain/kotlin/fr/outadoc/justchatting/feature/chat/presentation/ui/AndroidChatNotifier.kt
@@ -13,37 +13,32 @@ import androidx.core.content.LocusIdCompat
 import fr.outadoc.justchatting.feature.chat.presentation.ChatConnectionService
 import fr.outadoc.justchatting.feature.chat.presentation.ChatNotifier
 import fr.outadoc.justchatting.feature.chat.presentation.getProfileImageIcon
-import fr.outadoc.justchatting.feature.preferences.domain.PreferenceRepository
-import fr.outadoc.justchatting.feature.preferences.domain.model.AppPreferences
 import fr.outadoc.justchatting.feature.shared.domain.model.User
 import fr.outadoc.justchatting.shared.ui.R
 import fr.outadoc.justchatting.utils.core.toPendingActivityIntent
 import fr.outadoc.justchatting.utils.core.toPendingForegroundServiceIntent
 import fr.outadoc.justchatting.utils.logging.logError
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
 
 internal class AndroidChatNotifier(
     private val context: Context,
-    private val preferenceRepository: PreferenceRepository,
 ) : ChatNotifier {
     companion object {
         private const val NOTIFICATION_CHANNEL_ID = "channel_bubble"
         private const val KEY_QUICK_REPLY_TEXT = "quick_reply"
     }
 
+    // System-level state only; the enableNotifications app preference is checked
+    // by callers, which already observe it. Reading it here would require blocking
+    // on DataStore from the main thread.
     override val areNotificationsEnabled: Boolean
         get() {
             val nm = NotificationManagerCompat.from(context)
             val notificationsPermissionCheck: Int =
                 ContextCompat.checkSelfPermission(context, "android.permission.POST_NOTIFICATIONS")
 
-            val currentPrefs: AppPreferences =
-                runBlocking { preferenceRepository.currentPreferences.first() }
-
             return when (notificationsPermissionCheck) {
                 PackageManager.PERMISSION_GRANTED -> {
-                    nm.areNotificationsEnabled() && currentPrefs.enableNotifications
+                    nm.areNotificationsEnabled()
                 }
 
                 else -> {

--- a/shared-ui/src/commonMain/kotlin/fr/outadoc/justchatting/feature/chat/presentation/ui/ChatList.kt
+++ b/shared-ui/src/commonMain/kotlin/fr/outadoc/justchatting/feature/chat/presentation/ui/ChatList.kt
@@ -156,7 +156,12 @@ internal fun ChatList(
 
             itemsIndexed(
                 items = entries,
-                key = { _, item -> item.hashCode() },
+                // Lazy list keys must be unique; a raw hashCode() would crash the whole
+                // screen on the first collision between two distinct messages.
+                key = { _, item ->
+                    item.body?.messageId
+                        ?: "${item.timestamp.toEpochMilliseconds()}-${item.hashCode()}"
+                },
                 contentType = { _, item ->
                     when (item) {
                         is ChatListItem.Message.Highlighted -> 1

--- a/shared/api/android/shared.api
+++ b/shared/api/android/shared.api
@@ -318,13 +318,15 @@ public final class fr/outadoc/justchatting/feature/chat/domain/model/Chatter {
 public final class fr/outadoc/justchatting/feature/chat/domain/model/ConnectionStatus {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (ZI)V
-	public synthetic fun <init> (ZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZII)V
+	public synthetic fun <init> (ZIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()I
-	public final fun copy (ZI)Lfr/outadoc/justchatting/feature/chat/domain/model/ConnectionStatus;
-	public static synthetic fun copy$default (Lfr/outadoc/justchatting/feature/chat/domain/model/ConnectionStatus;ZIILjava/lang/Object;)Lfr/outadoc/justchatting/feature/chat/domain/model/ConnectionStatus;
+	public final fun component3 ()I
+	public final fun copy (ZII)Lfr/outadoc/justchatting/feature/chat/domain/model/ConnectionStatus;
+	public static synthetic fun copy$default (Lfr/outadoc/justchatting/feature/chat/domain/model/ConnectionStatus;ZIIILjava/lang/Object;)Lfr/outadoc/justchatting/feature/chat/domain/model/ConnectionStatus;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAliveConnections ()I
 	public final fun getRegisteredListeners ()I
 	public fun hashCode ()I
 	public final fun isAlive ()Z

--- a/shared/api/desktop/shared.api
+++ b/shared/api/desktop/shared.api
@@ -326,13 +326,15 @@ public final class fr/outadoc/justchatting/feature/chat/domain/model/Chatter {
 public final class fr/outadoc/justchatting/feature/chat/domain/model/ConnectionStatus {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (ZI)V
-	public synthetic fun <init> (ZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZII)V
+	public synthetic fun <init> (ZIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()I
-	public final fun copy (ZI)Lfr/outadoc/justchatting/feature/chat/domain/model/ConnectionStatus;
-	public static synthetic fun copy$default (Lfr/outadoc/justchatting/feature/chat/domain/model/ConnectionStatus;ZIILjava/lang/Object;)Lfr/outadoc/justchatting/feature/chat/domain/model/ConnectionStatus;
+	public final fun component3 ()I
+	public final fun copy (ZII)Lfr/outadoc/justchatting/feature/chat/domain/model/ConnectionStatus;
+	public static synthetic fun copy$default (Lfr/outadoc/justchatting/feature/chat/domain/model/ConnectionStatus;ZIIILjava/lang/Object;)Lfr/outadoc/justchatting/feature/chat/domain/model/ConnectionStatus;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAliveConnections ()I
 	public final fun getRegisteredListeners ()I
 	public fun hashCode ()I
 	public final fun isAlive ()Z

--- a/shared/api/shared.klib.api
+++ b/shared/api/shared.klib.api
@@ -574,8 +574,10 @@ final class fr.outadoc.justchatting.feature.chat.domain.model/Chatter { // fr.ou
 }
 
 final class fr.outadoc.justchatting.feature.chat.domain.model/ConnectionStatus { // fr.outadoc.justchatting.feature.chat.domain.model/ConnectionStatus|null[0]
-    constructor <init>(kotlin/Boolean = ..., kotlin/Int = ...) // fr.outadoc.justchatting.feature.chat.domain.model/ConnectionStatus.<init>|<init>(kotlin.Boolean;kotlin.Int){}[0]
+    constructor <init>(kotlin/Boolean = ..., kotlin/Int = ..., kotlin/Int = ...) // fr.outadoc.justchatting.feature.chat.domain.model/ConnectionStatus.<init>|<init>(kotlin.Boolean;kotlin.Int;kotlin.Int){}[0]
 
+    final val aliveConnections // fr.outadoc.justchatting.feature.chat.domain.model/ConnectionStatus.aliveConnections|{}aliveConnections[0]
+        final fun <get-aliveConnections>(): kotlin/Int // fr.outadoc.justchatting.feature.chat.domain.model/ConnectionStatus.aliveConnections.<get-aliveConnections>|<get-aliveConnections>(){}[0]
     final val isAlive // fr.outadoc.justchatting.feature.chat.domain.model/ConnectionStatus.isAlive|{}isAlive[0]
         final fun <get-isAlive>(): kotlin/Boolean // fr.outadoc.justchatting.feature.chat.domain.model/ConnectionStatus.isAlive.<get-isAlive>|<get-isAlive>(){}[0]
     final val registeredListeners // fr.outadoc.justchatting.feature.chat.domain.model/ConnectionStatus.registeredListeners|{}registeredListeners[0]
@@ -583,7 +585,8 @@ final class fr.outadoc.justchatting.feature.chat.domain.model/ConnectionStatus {
 
     final fun component1(): kotlin/Boolean // fr.outadoc.justchatting.feature.chat.domain.model/ConnectionStatus.component1|component1(){}[0]
     final fun component2(): kotlin/Int // fr.outadoc.justchatting.feature.chat.domain.model/ConnectionStatus.component2|component2(){}[0]
-    final fun copy(kotlin/Boolean = ..., kotlin/Int = ...): fr.outadoc.justchatting.feature.chat.domain.model/ConnectionStatus // fr.outadoc.justchatting.feature.chat.domain.model/ConnectionStatus.copy|copy(kotlin.Boolean;kotlin.Int){}[0]
+    final fun component3(): kotlin/Int // fr.outadoc.justchatting.feature.chat.domain.model/ConnectionStatus.component3|component3(){}[0]
+    final fun copy(kotlin/Boolean = ..., kotlin/Int = ..., kotlin/Int = ...): fr.outadoc.justchatting.feature.chat.domain.model/ConnectionStatus // fr.outadoc.justchatting.feature.chat.domain.model/ConnectionStatus.copy|copy(kotlin.Boolean;kotlin.Int;kotlin.Int){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // fr.outadoc.justchatting.feature.chat.domain.model/ConnectionStatus.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // fr.outadoc.justchatting.feature.chat.domain.model/ConnectionStatus.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // fr.outadoc.justchatting.feature.chat.domain.model/ConnectionStatus.toString|toString(){}[0]

--- a/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/chat/data/irc/BaseChatWebSocket.kt
+++ b/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/chat/data/irc/BaseChatWebSocket.kt
@@ -68,6 +68,19 @@ internal abstract class BaseChatWebSocket(
 
     override val connectionStatus = _connectionStatus.asStateFlow()
 
+    // This socket is a singleton, but every collector of the event flow holds its own
+    // websocket connection. isAlive is derived from connection counts: a boolean written
+    // directly from each connection would let one channel's live connection mask another
+    // channel's dead one.
+    private fun updateConnectionStatus(transform: (ConnectionStatus) -> ConnectionStatus) {
+        _connectionStatus.update { current ->
+            val next = transform(current)
+            next.copy(
+                isAlive = next.aliveConnections > 0 && next.aliveConnections >= next.registeredListeners,
+            )
+        }
+    }
+
     /**
      * Callbacks describing one collection of the event flow. [onConnected] is invoked
      * once per established connection, [onCommandReceived] for every parsed command
@@ -97,7 +110,7 @@ internal abstract class BaseChatWebSocket(
 
     protected fun chatEventFlow(createSession: () -> Session): Flow<ChatEvent> = channelFlow {
         val session = createSession()
-        _connectionStatus.update { it.copy(registeredListeners = it.registeredListeners + 1) }
+        updateConnectionStatus { it.copy(registeredListeners = it.registeredListeners + 1) }
         try {
             networkStateObserver.state.collectLatest { netState ->
                 if (netState is NetworkStateObserver.NetworkState.Available) {
@@ -114,18 +127,17 @@ internal abstract class BaseChatWebSocket(
                     }
                 } else {
                     logDebug(logTag) { "Network is out, waiting" }
-                    _connectionStatus.update { it.copy(isAlive = false) }
                 }
             }
         } finally {
-            _connectionStatus.update { it.copy(registeredListeners = it.registeredListeners - 1) }
+            updateConnectionStatus { it.copy(registeredListeners = it.registeredListeners - 1) }
         }
     }.flowOn(dispatchersProvider.io)
 
     private suspend fun ProducerScope<ChatEvent>.connect(session: Session) {
         httpClient.webSocket(endpoint) {
             logDebug(logTag) { "Socket open" }
-            _connectionStatus.update { it.copy(isAlive = true) }
+            updateConnectionStatus { it.copy(aliveConnections = it.aliveConnections + 1) }
             try {
                 val connection = Connection(this, this@connect)
                 session.onConnected(connection)
@@ -153,7 +165,7 @@ internal abstract class BaseChatWebSocket(
                     }
                 }
             } finally {
-                _connectionStatus.update { it.copy(isAlive = false) }
+                updateConnectionStatus { it.copy(aliveConnections = it.aliveConnections - 1) }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/chat/data/irc/IrcMessageTagExt.kt
+++ b/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/chat/data/irc/IrcMessageTagExt.kt
@@ -17,13 +17,22 @@ internal fun Map<String, String?>.parseEmotes(message: String): List<Emote>? = t
     ?.flatMap { emote ->
         emote.value
             ?.split(",")
-            ?.map { indexes ->
+            ?.mapNotNull { indexes ->
+                // Indices are server-provided and occasionally out of range or
+                // malformed; skip the emote rather than crash the parser.
                 val index = indexes.split("-")
-                val begin = index[0].toInt()
-                val end = index[1].toInt()
+                val begin = index.getOrNull(0)?.toIntOrNull() ?: return@mapNotNull null
+                val end = index.getOrNull(1)?.toIntOrNull() ?: return@mapNotNull null
 
-                val realBegin = message.offsetByCodePoints(0, begin)
+                val realBegin =
+                    try {
+                        message.offsetByCodePoints(0, begin)
+                    } catch (e: IndexOutOfBoundsException) {
+                        return@mapNotNull null
+                    }
                 val realEnd = if (begin == realBegin) end else end + realBegin - begin
+
+                if (realBegin > realEnd || realEnd >= message.length) return@mapNotNull null
 
                 ChatEmote(
                     id = emote.key,
@@ -156,8 +165,8 @@ internal val Map<String, String?>.targetUserId: String?
 internal val Map<String, String?>.systemMsg: String?
     get() = this["system-msg"]?.takeUnless { it.isEmpty() }
 
-internal val Map<String, String?>.userId: String
-    get() = this["user-id"]!!
+internal val Map<String, String?>.userId: String?
+    get() = this["user-id"]?.takeUnless { it.isEmpty() }
 
 private fun String.splitAndMakeMap(
     split: String,

--- a/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/chat/data/irc/TwitchIrcCommandParser.kt
+++ b/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/chat/data/irc/TwitchIrcCommandParser.kt
@@ -5,13 +5,24 @@ import fr.outadoc.justchatting.feature.chat.data.irc.parser.irc.message.IrcMessa
 import fr.outadoc.justchatting.feature.chat.data.irc.parser.irc.message.rfc1459.NoticeMessage
 import fr.outadoc.justchatting.feature.chat.data.irc.parser.irc.message.rfc1459.PrivMsgMessage
 import fr.outadoc.justchatting.feature.chat.domain.model.ChatEvent
+import fr.outadoc.justchatting.utils.logging.logError
 import fr.outadoc.justchatting.utils.logging.logWarning
 import kotlin.time.Clock
 
 internal class TwitchIrcCommandParser(
     private val clock: Clock,
 ) {
-    fun parse(message: String): ChatEvent? {
+    fun parse(message: String): ChatEvent? = try {
+        parseInternal(message)
+    } catch (e: Exception) {
+        // A malformed line must never propagate: an exception thrown here would
+        // close the chat socket, and recent-message backfill would replay the same
+        // line on every reconnection.
+        logError<TwitchIrcCommandParser>(e) { "Failed to parse message: $message" }
+        null
+    }
+
+    private fun parseInternal(message: String): ChatEvent? {
         val ircMessage = IrcMessageParser.parse(message)
         val parsedMessage =
             when (ircMessage?.command) {
@@ -150,7 +161,7 @@ internal class TwitchIrcCommandParser(
 
         return ChatEvent.Message.ChatMessage(
             id = ircMessage.tags.id,
-            userId = ircMessage.tags.userId,
+            userId = ircMessage.tags.userId ?: return null,
             userLogin = ircMessage.tags.login ?: privateMessage.source.nick,
             userName = ircMessage.tags.displayName ?: privateMessage.source.nick,
             message = message,

--- a/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/chat/data/irc/parser/irc/message/IrcMessageParser.kt
+++ b/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/chat/data/irc/parser/irc/message/IrcMessageParser.kt
@@ -76,20 +76,44 @@ internal object IrcMessageParser : IIrcMessageParser {
                     unparsedTags,
                     CharacterCodes.SEMICOLON,
                     CharacterCodes.EQUALS,
-                ) {
-                    it
-                        .replace("\\:", CharacterCodes.SEMICOLON.toString())
-                        .replace("\\s", CharacterCodes.SPACE.toString())
-                        .replace("\\\\", CharacterCodes.BACKSLASH.toString())
-                        .replace("\\r", CharacterCodes.CR.toString())
-                        .replace("\\n", CharacterCodes.LF.toString())
-                }
+                    ::unescapeTagValue,
+                )
 
             position = ParseHelper.skipSpaces(line, nextSpace + 1)
             return Pair(tags, position)
         }
 
         return Pair(emptyMap(), position)
+    }
+
+    // Unescapes IRCv3 tag values in a single pass; sequential replace() calls
+    // would re-interpret backslashes produced by earlier replacements
+    // (e.g. "\\n" must yield "\n" the two characters, not a line feed).
+    private fun unescapeTagValue(raw: String): String = buildString {
+        var i = 0
+        while (i < raw.length) {
+            val c = raw[i]
+            if (c == CharacterCodes.BACKSLASH && i + 1 < raw.length) {
+                when (raw[i + 1]) {
+                    ':' -> append(CharacterCodes.SEMICOLON)
+
+                    's' -> append(CharacterCodes.SPACE)
+
+                    CharacterCodes.BACKSLASH -> append(CharacterCodes.BACKSLASH)
+
+                    'r' -> append(CharacterCodes.CR)
+
+                    'n' -> append(CharacterCodes.LF)
+
+                    // Unknown escape: the spec says to drop the backslash
+                    else -> append(raw[i + 1])
+                }
+                i += 2
+            } else {
+                append(c)
+                i++
+            }
+        }
     }
 
     private fun parsePrefix(

--- a/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/chat/data/irc/recent/RecentMessagesRepository.kt
+++ b/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/chat/data/irc/recent/RecentMessagesRepository.kt
@@ -16,7 +16,7 @@ internal class RecentMessagesRepository(
     ): Result<List<ChatEvent>> = withContext(dispatchersProvider.io) {
         recentMessagesApi
             .getRecentMessages(channelLogin, limit)
-            .map { response ->
+            .mapCatching { response ->
                 response.messages
                     .filterNot { message -> message.isBlank() }
                     .mapNotNull { message -> parser.parse(message) }

--- a/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/chat/domain/AggregateChatEventHandler.kt
+++ b/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/chat/domain/AggregateChatEventHandler.kt
@@ -27,6 +27,7 @@ internal class AggregateChatEventHandler(
                 ConnectionStatus(
                     isAlive = acc.isAlive && status.isAlive,
                     registeredListeners = acc.registeredListeners + status.registeredListeners,
+                    aliveConnections = acc.aliveConnections + status.aliveConnections,
                 )
             }
         }.distinctUntilChanged()

--- a/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/chat/domain/model/ConnectionStatus.kt
+++ b/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/chat/domain/model/ConnectionStatus.kt
@@ -3,4 +3,5 @@ package fr.outadoc.justchatting.feature.chat.domain.model
 public data class ConnectionStatus(
     val isAlive: Boolean = false,
     val registeredListeners: Int = 0,
+    val aliveConnections: Int = 0,
 )

--- a/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/chat/presentation/ChatStateReducer.kt
+++ b/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/chat/presentation/ChatStateReducer.kt
@@ -101,7 +101,11 @@ internal class ChatStateReducer {
                 .addAll(
                     index = 0,
                     messages.asReversed(),
-                ).distinct()
+                )
+                // Deduplicate by message id when there is one: the same message can be
+                // received twice with different timestamps (e.g. live + recent-messages
+                // backfill), and message ids are used as unique list keys by the UI.
+                .distinctBy { message -> message.body?.messageId ?: message }
                 .toPersistentList()
 
         val maxCount =

--- a/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/chat/presentation/EmoteUrlsExt.kt
+++ b/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/chat/presentation/EmoteUrlsExt.kt
@@ -1,11 +1,12 @@
 package fr.outadoc.justchatting.feature.chat.presentation
 
 import fr.outadoc.justchatting.feature.emotes.domain.model.EmoteUrls
+import kotlin.math.abs
 
 public fun EmoteUrls.getBestUrl(
     screenDensity: Float,
     isDarkTheme: Boolean,
 ): String = (if (isDarkTheme) dark else light)
-    .minByOrNull { (density, _) -> screenDensity - density }
+    .minByOrNull { (density, _) -> abs(screenDensity - density) }
     ?.value
     ?: error("No urls available for this emote")

--- a/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/emotes/data/stv/StvEmotesServer.kt
+++ b/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/emotes/data/stv/StvEmotesServer.kt
@@ -27,7 +27,7 @@ internal class StvEmotesServer(
             .body<StvEmoteResponse>()
     }.map { response ->
         response.emotes
-            .map { emote -> emote.map() }
+            .mapNotNull { emote -> emote.map() }
     }
 
     override suspend fun getStvEmotes(channelId: String): Result<List<Emote>> = runCatching {
@@ -41,7 +41,7 @@ internal class StvEmotesServer(
             )
         } else {
             response.emoteSet.emotes
-                .map { emote -> emote.map() }
+                .mapNotNull { emote -> emote.map() }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/emotes/data/stv/model/StvEmoteExt.kt
+++ b/shared/src/commonMain/kotlin/fr/outadoc/justchatting/feature/emotes/data/stv/model/StvEmoteExt.kt
@@ -6,28 +6,32 @@ import fr.outadoc.justchatting.feature.emotes.domain.model.EmoteUrls
 
 private const val FLAG_IS_ZERO_WIDTH = 1 shl 8
 
-internal fun StvEmote.map(): Emote = Emote(
-    name = name,
-    ownerId = null,
-    isZeroWidth = flags.hasFlag(FLAG_IS_ZERO_WIDTH),
-    ratio =
-    supportedFiles.first().let { file ->
-        file.width.toFloat() / file.height.toFloat()
-    },
-    urls =
-    EmoteUrls(
-        anyTheme =
-        mapOf(
-            0f to
-                Uri
-                    .parse("https:${data.host.baseUrl}")
-                    .buildUpon()
-                    .appendPath(supportedFiles.first().name)
-                    .build()
-                    .toString(),
+// Returns null when the emote has no file in a supported format (e.g. AVIF-only),
+// so that a single such emote doesn't take down the whole 7TV emote source.
+internal fun StvEmote.map(): Emote? {
+    val file = supportedFiles.firstOrNull() ?: return null
+    if (file.height <= 0) return null
+
+    return Emote(
+        name = name,
+        ownerId = null,
+        isZeroWidth = flags.hasFlag(FLAG_IS_ZERO_WIDTH),
+        ratio = file.width.toFloat() / file.height.toFloat(),
+        urls =
+        EmoteUrls(
+            anyTheme =
+            mapOf(
+                0f to
+                    Uri
+                        .parse("https:${data.host.baseUrl}")
+                        .buildUpon()
+                        .appendPath(file.name)
+                        .build()
+                        .toString(),
+            ),
         ),
-    ),
-)
+    )
+}
 
 private val StvEmote.supportedFiles: List<StvEmoteFiles>
     get() {

--- a/shared/src/commonTest/kotlin/fr/outadoc/justchatting/feature/chat/presentation/EmoteUrlsExtTest.kt
+++ b/shared/src/commonTest/kotlin/fr/outadoc/justchatting/feature/chat/presentation/EmoteUrlsExtTest.kt
@@ -1,0 +1,33 @@
+package fr.outadoc.justchatting.feature.chat.presentation
+
+import fr.outadoc.justchatting.feature.emotes.domain.model.EmoteUrls
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class EmoteUrlsExtTest {
+    private val urls =
+        EmoteUrls(
+            anyTheme =
+            mapOf(
+                1f to "1x",
+                2f to "2x",
+                4f to "4x",
+            ),
+        )
+
+    @Test
+    fun `Picks the exact density when available`() {
+        assertEquals("2x", urls.getBestUrl(screenDensity = 2f, isDarkTheme = false))
+    }
+
+    @Test
+    fun `Picks the closest density, not the largest`() {
+        assertEquals("1x", urls.getBestUrl(screenDensity = 1.2f, isDarkTheme = false))
+        assertEquals("2x", urls.getBestUrl(screenDensity = 2.5f, isDarkTheme = false))
+    }
+
+    @Test
+    fun `Picks the largest density when the screen is denser than all candidates`() {
+        assertEquals("4x", urls.getBestUrl(screenDensity = 8f, isDarkTheme = false))
+    }
+}

--- a/shared/src/commonTest/kotlin/fr/outadoc/justchatting/util/chat/TwitchIrcCommandParserRobustnessTest.kt
+++ b/shared/src/commonTest/kotlin/fr/outadoc/justchatting/util/chat/TwitchIrcCommandParserRobustnessTest.kt
@@ -1,0 +1,103 @@
+package fr.outadoc.justchatting.util.chat
+
+import fr.outadoc.justchatting.feature.chat.data.irc.TwitchIrcCommandParser
+import fr.outadoc.justchatting.feature.chat.domain.model.ChatEvent
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+
+/**
+ * A parse failure must never throw: an exception would close the chat socket, and
+ * recent-message backfill would replay the same line on every reconnection.
+ */
+internal class TwitchIrcCommandParserRobustnessTest {
+    private lateinit var parser: TwitchIrcCommandParser
+
+    @BeforeTest
+    fun before() {
+        parser = TwitchIrcCommandParser(Clock.System)
+    }
+
+    @Test
+    fun `PRIVMSG without user-id tag is dropped instead of throwing`() {
+        assertNull(
+            parser.parse(
+                "@badges=;color=;display-name=ronni;emotes=;id=b34ccfc7-4977-403a-8a94-33c6bac34fb8;tmi-sent-ts=1507246572675 " +
+                    ":ronni!ronni@ronni.tmi.twitch.tv PRIVMSG #ronni :hello",
+            ),
+        )
+    }
+
+    @Test
+    fun `Emote indices out of message bounds are skipped`() {
+        val message =
+            parser.parse(
+                "@emotes=25:0-4,40-60;id=id;tmi-sent-ts=1507246572675;user-id=1337 " +
+                    ":ronni!ronni@ronni.tmi.twitch.tv PRIVMSG #ronni :Kappa hi",
+            )
+
+        assertIs<ChatEvent.Message.ChatMessage>(message)
+        assertEquals(listOf("Kappa"), message.embeddedEmotes.map { emote -> emote.name })
+    }
+
+    @Test
+    fun `Malformed emote ranges are skipped`() {
+        val message =
+            parser.parse(
+                "@emotes=25:0-4,notarange,7-;id=id;tmi-sent-ts=1507246572675;user-id=1337 " +
+                    ":ronni!ronni@ronni.tmi.twitch.tv PRIVMSG #ronni :Kappa hi",
+            )
+
+        assertIs<ChatEvent.Message.ChatMessage>(message)
+        assertEquals(listOf("Kappa"), message.embeddedEmotes.map { emote -> emote.name })
+    }
+
+    @Test
+    fun `Inverted emote range is skipped`() {
+        val message =
+            parser.parse(
+                "@emotes=25:4-0;id=id;tmi-sent-ts=1507246572675;user-id=1337 " +
+                    ":ronni!ronni@ronni.tmi.twitch.tv PRIVMSG #ronni :Kappa hi",
+            )
+
+        assertIs<ChatEvent.Message.ChatMessage>(message)
+        assertTrue(message.embeddedEmotes.isEmpty())
+    }
+
+    @Test
+    fun `Escaped backslash followed by n is not unescaped to a line feed`() {
+        // Wire value "a\\nb" is backslash-backslash-n-b, and must decode to "a\nb"
+        // (a literal backslash followed by the letter n), not to a line feed.
+        val message =
+            parser.parse(
+                "@display-name=a\\\\nb;id=id;tmi-sent-ts=1507246572675;user-id=1337 " +
+                    ":ronni!ronni@ronni.tmi.twitch.tv PRIVMSG #ronni :hello",
+            )
+
+        assertIs<ChatEvent.Message.ChatMessage>(message)
+        assertEquals("a\\nb", message.userName)
+    }
+
+    @Test
+    fun `Standard tag escapes are unescaped`() {
+        val message =
+            parser.parse(
+                "@display-name=a\\sb\\:c\\\\d;id=id;tmi-sent-ts=1507246572675;user-id=1337 " +
+                    ":ronni!ronni@ronni.tmi.twitch.tv PRIVMSG #ronni :hello",
+            )
+
+        assertIs<ChatEvent.Message.ChatMessage>(message)
+        assertEquals("a b;c\\d", message.userName)
+    }
+
+    @Test
+    fun `Garbage lines do not throw`() {
+        assertNull(parser.parse("@;;;===  :::"))
+        assertNull(parser.parse("@"))
+        assertNull(parser.parse(":"))
+    }
+}


### PR DESCRIPTION
- Parser hardening — user-id is no longer force-unwrapped (message dropped if missing), emote ranges are validated (malformed/inverted/out-of-bounds indices are skipped, including the offsetByCodePoints bounds case), TwitchIrcCommandParser.parse has a last-resort try/catch, and RecentMessagesRepository uses mapCatching so a bad backfill message becomes a logged Result failure instead of a reconnect loop.
- Lazy list keys — ChatList now keys on messageId (falling back to timestamp + hash for ID-less items), and the reducer deduplicates by messageId, which both guarantees key uniqueness and prevents visible duplicate messages when live and backfill deliver the same message with different timestamps.
- getBestUrl uses abs() — closest density wins instead of always the largest.
- IRCv3 tag unescaping is now a single pass instead of order-sensitive chained replace() calls.
- StvEmote.map() returns null for emotes with no GIF/WEBP file (or zero height) instead of throwing and taking down the whole 7TV source.
- AndroidChatNotifier no longer does runBlocking DataStore reads during composition; it checks system state only, since every call site already observes prefs.enableNotifications through canOpenInBubble.
- BaseChatWebSocket derives isAlive from an aliveConnections counter (ConnectionStatus gained the field, ABI dumps regenerated), so with two open chats a dead connection can no longer be masked by a live one.

New tests: TwitchIrcCommandParserRobustnessTest and EmoteUrlsExtTest (density selection).